### PR TITLE
Update module to support running in SYSTEM context

### DIFF
--- a/WingetTools.psd1
+++ b/WingetTools.psd1
@@ -5,7 +5,7 @@
 @{
 
     RootModule           = 'WingetTools.psm1'
-    ModuleVersion        = '1.4.0'
+    ModuleVersion        = '1.4.1'
     CompatiblePSEditions = @('Desktop', 'Core')
     GUID                 = '1130bb85-58d1-487d-9763-c38011f9613d'
     Author               = 'Jeff Hicks'
@@ -25,7 +25,7 @@
         'formats\wginstalled.format.ps1xml'
     )
     FunctionsToExport    = 'Get-WGPackage', 'Install-Winget', 'Get-WGReleaseNote',
-    'Get-WGInstalled', 'Invoke-WGUpgrade', 'Get-WGUpgrade', 'Test-WGVersion'
+    'Get-WGInstalled', 'Invoke-WGUpgrade', 'Get-WGUpgrade', 'Test-WGVersion' , 'Get-WingetPath'
     AliasesToExport      = 'wglatest', 'iwg'
     PrivateData          = @{
         PSData = @{

--- a/functions/Get-WGInstalled.ps1
+++ b/functions/Get-WGInstalled.ps1
@@ -10,15 +10,7 @@ Function Get-WGInstalled {
     Begin {
         Write-Verbose "[$((Get-Date).TimeofDay) BEGIN  ] Starting $($myinvocation.mycommand)"
         $tmpFile = "$env:temp\wgExport_{0}.json" -f (Get-Date -Format yyyymmdd)
-        $currentUser = whoami # get account running function
-		if ($currentUser -eq "nt authority\system")
-		{
-			# check if running in SYSTEM context set path to WINGET executable
-			$winget = gci "C:\Program Files\WindowsApps" -Recurse -File | where { $_.name -like "AppInstallerCLI.exe" -or $_.name -like "WinGet.exe" } | select -ExpandProperty fullname
-			# If there are multiple versions, select latest
-			if ($winget.count -gt 1) { $winget = $winget[-1] }
-		}
-		else { $winget = "$env:localappdata\Microsoft\WindowsApps\Winget.exe" }
+        $Winget = Get-WingetPath
     } #begin
 
     Process {

--- a/functions/Get-WGInstalled.ps1
+++ b/functions/Get-WGInstalled.ps1
@@ -10,11 +10,20 @@ Function Get-WGInstalled {
     Begin {
         Write-Verbose "[$((Get-Date).TimeofDay) BEGIN  ] Starting $($myinvocation.mycommand)"
         $tmpFile = "$env:temp\wgExport_{0}.json" -f (Get-Date -Format yyyymmdd)
+        $currentUser = whoami # get account running function
+		if ($currentUser -eq "nt authority\system")
+		{
+			# check if running in SYSTEM context set path to WINGET executable
+			$winget = gci "C:\Program Files\WindowsApps" -Recurse -File | where { $_.name -like "AppInstallerCLI.exe" -or $_.name -like "WinGet.exe" } | select -ExpandProperty fullname
+			# If there are multiple versions, select latest
+			if ($winget.count -gt 1) { $winget = $winget[-1] }
+		}
+		else { $winget = "$env:localappdata\Microsoft\WindowsApps\Winget.exe" }
     } #begin
 
     Process {
         Write-Verbose "[$((Get-Date).TimeofDay) PROCESS] Building list of packages with a winget source"
-        [void](winget export -s winget -o $tmpFile --include-versions)
+        [void](& $winget export -s winget -o $tmpFile --include-versions)
         if (Test-Path -Path $tmpFile) {
             #import the json file
             Write-Verbose "[$((Get-Date).TimeofDay) PROCESS] Importing temporary JSON data"
@@ -25,12 +34,13 @@ Function Get-WGInstalled {
             Write-Verbose "[$((Get-Date).TimeofDay) PROCESS] Found $count packages. Getting details."
 
             $jobList = [system.collections.generic.list[object]]::new()
+            $wingetPath = $winget
             foreach ($pkg in $json.Sources.packages) {
                 Write-Verbose "[$((Get-Date).TimeofDay) PROCESS] $($pkg.PackageIdentifier)"
                 $i++
                 #9 August 2022 Using Threadjobs to get online package details for better scaling - JDH
                 $sb = {
-                    Param([object]$pkg, [string]$source)
+                    Param([object]$pkg, [string]$source, [string]$wingetPath)
                     Function _parseVersion {
                         #parse out odd characters from version strings
                         [cmdletbinding()]
@@ -49,7 +59,7 @@ Function Get-WGInstalled {
                     }
 
                     try {
-                        $show = winget show --id $pkg.PackageIdentifier --source $source
+                        $show = & $wingetPath show --id $pkg.PackageIdentifier --source $source
 
                         [regex]$rxname = "(?<=\w\s).*(?=\s\[[\S\.]+\])"
                         $installed = _parseVersion $pkg.version
@@ -75,7 +85,7 @@ Function Get-WGInstalled {
                     }
                 }
 
-                $joblist.add($(Start-ThreadJob -ScriptBlock $sb -ArgumentList $pkg, $source -Name wg))
+                $joblist.add($(Start-ThreadJob -ScriptBlock $sb -ArgumentList $pkg, $source, $wingetPath -Name wg))
 
             } #foreach pkg
 

--- a/functions/Get-WGPackage.ps1
+++ b/functions/Get-WGPackage.ps1
@@ -51,7 +51,8 @@ Function Get-WGPackage {
 
         Write-Verbose "[$((Get-Date).TimeofDay) BEGIN  ] Using source $source"
         Write-Verbose "[$((Get-Date).TimeofDay) BEGIN  ] Using Parameter set $($PSCmdlet.ParameterSetName)"
-        $cmdText = "winget show --source $source"
+        $winget = Get-WingetPath
+        $cmdText = "$winget show --source $source"
 
         Switch ($PSCmdlet.ParameterSetName) {
             "Name" {

--- a/functions/Get-WingetPath.ps1
+++ b/functions/Get-WingetPath.ps1
@@ -3,7 +3,7 @@ $currentUser = whoami # get account running function
 	if ($currentUser -eq "nt authority\system")
 	{
 	# check if running in SYSTEM context set path to WINGET executable
-	$winget = Get-ChildItem -path "C:\Program Files\WindowsApps" -Recurse -File | where-object { $_.name -like "AppInstallerCLI.exe" -or $_.name -like "WinGet.exe" } | Select-Object -ExpandProperty fullname
+	$winget = Get-ChildItem -path "$env:ProgramFiles\WindowsApps" -Recurse -File | where-object { $_.name -like "AppInstallerCLI.exe" -or $_.name -like "WinGet.exe" } | Select-Object -ExpandProperty fullname
 	# If there are multiple versions, select latest
 	if ($winget.count -gt 1) { $winget = $winget[-1] }
 	}

--- a/functions/Get-WingetPath.ps1
+++ b/functions/Get-WingetPath.ps1
@@ -1,0 +1,12 @@
+﻿function Get-WingetPath {
+$currentUser = whoami # get account running function
+	if ($currentUser -eq "nt authority\system")
+	{
+	# check if running in SYSTEM context set path to WINGET executable
+	$winget = gci "C:\Program Files\WindowsApps" -Recurse -File | where { $_.name -like "AppInstallerCLI.exe" -or $_.name -like "WinGet.exe" } | select -ExpandProperty fullname
+	# If there are multiple versions, select latest
+	if ($winget.count -gt 1) { $winget = $winget[-1] }
+	}
+	else { $winget = "$env:localappdata\Microsoft\WindowsApps\Winget.exe" }
+    return $winget
+}

--- a/functions/Get-WingetPath.ps1
+++ b/functions/Get-WingetPath.ps1
@@ -3,7 +3,7 @@ $currentUser = whoami # get account running function
 	if ($currentUser -eq "nt authority\system")
 	{
 	# check if running in SYSTEM context set path to WINGET executable
-	$winget = gci "C:\Program Files\WindowsApps" -Recurse -File | where { $_.name -like "AppInstallerCLI.exe" -or $_.name -like "WinGet.exe" } | select -ExpandProperty fullname
+	$winget = Get-ChildItem -path "C:\Program Files\WindowsApps" -Recurse -File | where-object { $_.name -like "AppInstallerCLI.exe" -or $_.name -like "WinGet.exe" } | Select-Object -ExpandProperty fullname
 	# If there are multiple versions, select latest
 	if ($winget.count -gt 1) { $winget = $winget[-1] }
 	}

--- a/functions/Get-WingetUpgrade.ps1
+++ b/functions/Get-WingetUpgrade.ps1
@@ -54,8 +54,9 @@ Function Get-WGUpgrade {
 
     Write-Verbose "Starting $($MyInvocation.MyCommand)"
     #create a list to hold the results
+    $Winget = Get-WingetPath
     $list = [System.Collections.Generic.list[object]]::New()
-    $up = (winget upgrade).trim() | Where-Object { $_ -match "\d+\.\d+\s(?!MB)" }
+    $up = (& $winget upgrade).trim() | Where-Object { $_ -match "\d+\.\d+\s(?!MB)" }
 
     Write-Verbose "Found $($up.count) available upgrades"
 

--- a/functions/Invoke-WingetUpgrade.ps1
+++ b/functions/Invoke-WingetUpgrade.ps1
@@ -28,6 +28,7 @@ Function Invoke-WGUpgrade {
 
     Begin {
         Write-Verbose "Starting $($MyInvocation.MyCommand)"
+        $winget = Get-WingetPath
     } #begin
     Process {
         #set a flag indicating items were process in this script block
@@ -42,22 +43,22 @@ Function Invoke-WGUpgrade {
             foreach ($item in $InputObject) {
                 if ($pscmdlet.ShouldProcess($item.id, "Upgrade from $($item.version) to $($item.Available)")) {
                     if ($item.source) {
-                        winget upgrade --id $item.id --source $item.source --silent --accept-package-agreements --accept-source-agreements
+                        & $winget upgrade --id $item.id --source $item.source --silent --accept-package-agreements --accept-source-agreements
                     }
                     else {
-                        winget upgrade --id $item.id --silent --accept-package-agreements --accept-source-agreements
+                        & $winget upgrade --id $item.id --silent --accept-package-agreements --accept-source-agreements
                     }
                 }
             } #foreach
         }
         elseif ($pscmdlet.ParameterSetName -eq 'all' -AND $IncludeUnknown) {
             if ($pscmdlet.ShouldProcess("all installed and unknown packages")) {
-                winget upgrade --all --include-unknown --silent
+                & $winget upgrade --all --include-unknown --silent
             }
         }
         elseif ($pscmdlet.ParameterSetName -eq 'all') {
             if ($pscmdlet.ShouldProcess("all installed")) {
-                winget upgrade --all --silent
+                & $winget upgrade --all --silent
             }
         }
         else {


### PR DESCRIPTION
Ive added a new function "Get-WingetPath" and updated other functions where needed to explicitly state the path to the Winget executable. Calling the Winget executable works under system context, however the  alias "winget" is not available to system. 