### PR TITLE
fix for  • symbol

### DIFF
--- a/functions/private.ps1
+++ b/functions/private.ps1
@@ -13,7 +13,7 @@ Function _convert {
     Process {
         Try {
             Write-Verbose "[$((Get-Date).TimeofDay) CONVERT] Converting to YAML"
-            $yml = $package.replace(" - ", " ") | Select-Object -Skip 1 | Where-Object { $_ -match "^(\s+)?(\b(\w+)\b).*:" } | ConvertFrom-Yaml -ErrorAction stop
+            $yml = $package.replace(" - ", " ").replace("ÔÇó", "*") | Select-Object -Skip 1 | Where-Object { $_ -match "^(\s+)?(\b(\w+)\b).*:" } | ConvertFrom-Yaml -ErrorAction stop
         }
         Catch {
             Write-Warning "Failed to convert to YAML. $($_.exception.message)"


### PR DESCRIPTION
I experience that the function get-wgpackege fails with wingit id "putty.putty"

This happens because of the release notes that are in the winget package.
The release notes contain the • symbol what powershell replace with 'ÔÇó'

So, I added an extra replace step to change the 'ÔÇó' to another readable symbol *.

Now the regex in the convert private function takes the right lines and the convertfrom-yaml is working again. 