### PR TITLE
Removed "- 1"

### DIFF
--- a/functions/private.ps1
+++ b/functions/private.ps1
@@ -24,7 +24,7 @@ Function _convert {
         $j = $list.FindIndex({ $args[0] -match "^Installer:" })
         if ($i -gt 0 -AND $j -gt $i) {
             Write-Verbose "[$((Get-Date).TimeofDay) CONVERT] Removing lines $i to $($j-1)"
-            $list.RemoveRange($i, ($j - 1) - $i)
+            $list.RemoveRange($i, ($j - $i)
         }
 
         Try {


### PR DESCRIPTION
The - 1 on line 27 removes one line to much from the list object.

I have seen this problem with the app winget ID: Zoom.zoom.

The list object before the removal of the release notes:

```
Version: 5.12.10137
Publisher: Zoom
Publisher Url: https://zoom.us/
Publisher Support Url: https://support.zoom.us/
Author: Zoom Video Communications, Inc.
Description: Zooms secure, reliable video platform powers all of your communication needs, including meetings, chat, phone, webinars, and online events.
Homepage: https://zoom.us/
License: Proprietary
License Url: https://explore.zoom.us/en/terms/
Privacy Url: https://explore.zoom.us/en/privacy/
Copyright: Copyright 2012-2022 Zoom Video Communications, Inc. All rights reserved.
Release Notes: Resolved Issues
**Documentation:
  Learning Center: https://learning.zoom.us/learn**
Installer:
  Type: exe
  Download Url: https://cdn.zoom.us/prod/5.12.6.10137/x64/ZoomInstallerFull.exe
  SHA256: f84b60a1ee9b8702ded74833dfffa3745d1122ba6110e1b98f1b66e91ae1d2e7
  Release Date: 2022-11-07
```

The list object after the removal of the release notes:

```
Version: 5.12.10137
Publisher: Zoom
Publisher Url: https://zoom.us/
Publisher Support Url: https://support.zoom.us/
Author: Zoom Video Communications, Inc.
Description: Zooms secure, reliable video platform powers all of your communication needs, including meetings, chat, phone, webinars, and online events.
Homepage: https://zoom.us/
License: Proprietary
License Url: https://explore.zoom.us/en/terms/
Privacy Url: https://explore.zoom.us/en/privacy/
Copyright: Copyright 2012-2022 Zoom Video Communications, Inc. All rights reserved.
  **Learning Center: https://learning.zoom.us/learn**
Installer:
  Type: exe
  Download Url: https://cdn.zoom.us/prod/5.12.6.10137/x64/ZoomInstallerFull.exe
  SHA256: f84b60a1ee9b8702ded74833dfffa3745d1122ba6110e1b98f1b66e91ae1d2e7
  Release Date: 2022-11-07
```

I marked the issue with **.
The script now also removes the Documentation key.
This breaks the convert from yml.

Tested with a lot of other apps and it seeme that the removal of the extra line just removes some other crap info next to release notes.

But for zoom.zoom it breaks the convertion.